### PR TITLE
PERF: Optimize StringExtensions.cs

### DIFF
--- a/src/PainlessUtils/StringExtensions.cs
+++ b/src/PainlessUtils/StringExtensions.cs
@@ -95,7 +95,7 @@ namespace Coding4fun.PainlessUtils
 
                 if (separatorLength > 0 && wordNumber + 1 != wordRanges.Length)
                 {
-                    separator!.ToCharArray().CopyTo(textBuffer.AsSpan(charNumber, separatorLength));
+                    separator!.AsSpan().CopyTo(textBuffer.AsSpan(charNumber, separatorLength));
                     charNumber += separatorLength;
                 }
             }


### PR DESCRIPTION
Hi @scrappyCoco, I've tried to make some performance optimizations to this repo. Following are the benchmark results before and after the changes:

**Benchmarks before changes:**
|    Method |       Mean |    Error |    StdDev |     Median |  Gen 0 | Allocated |
|---------- |-----------:|---------:|----------:|-----------:|-------:|----------:|
|  Painless |   468.5 ns | 22.00 ns |  64.53 ns |   458.2 ns | 0.2255 |     472 B |
| Substring | 1,074.6 ns | 59.39 ns | 175.11 ns | 1,129.8 ns | 0.3014 |     632 B |

**Benchmarks after changes:**
|    Method |     Mean |    Error |    StdDev |   Median |  Gen 0 | Allocated |
|---------- |---------:|---------:|----------:|---------:|-------:|----------:|
|  Painless | 299.8 ns |  5.94 ns |   8.32 ns | 299.9 ns | 0.2103 |     440 B |
| Substring | 958.1 ns | 79.57 ns | 234.62 ns | 890.2 ns | 0.3014 |     632 B |

As you can see the durations and allocations have gone down. I've also made sure that all the unit tests pass following these changes as well. Could you please confirm whether or not you think my changes are valid?

Thank you!
